### PR TITLE
Improve georeferencer UI with structured workflow and modern styling

### DIFF
--- a/LOG.md
+++ b/LOG.md
@@ -60,3 +60,10 @@
 - Added sample-load behavior to center the map on West Palm Beach, Florida at zoom level 13 for faster alignment workflow.
 - Added `currentImageName` state so world/prj downloads use the correct base filename for both uploaded and sample-loaded images.
 - Performed diagnostics check on `index.html`; no file-level errors found.
+
+## 2026-03-14 (ui/ux polish pass)
+- Refined the interface into a clearer 3-step workflow with sectioned panels for image loading, GCP management, and export settings.
+- Applied a cohesive modern dark theme (improved spacing, hierarchy, controls, badges, and map help strip) to improve readability and reduce cognitive load.
+- Improved responsive behavior for smaller screens by collapsing to a stacked layout and resizing the image pane for mobile/tablet widths.
+- Kept existing georeferencing behavior intact while making interactions and labels more discoverable.
+- Ran repository checks and captured an updated UI screenshot for verification.

--- a/index.html
+++ b/index.html
@@ -5,31 +5,106 @@
   <title>In-Browser Georeferencer (Affine → World File)</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <style>
-    html, body { height: 100%; margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial;}
-    .app { display: grid; grid-template-columns: 420px 1fr; height: 100%; }
-    .left { padding: 12px; overflow: auto; border-right: 1px solid #ddd; }
-    .right { display: grid; grid-template-rows: 1fr 180px; }
-    #imgPane { border: 1px solid #ccc; width: 100%; height: 420px; background:#f8f8f8; overflow:hidden; }
+    :root {
+      color-scheme: dark;
+      --bg: #0b1220;
+      --bg-raised: #151f33;
+      --panel: #111a2b;
+      --line: #253550;
+      --line-soft: #1b2941;
+      --text: #e6edf7;
+      --muted: #9eb0cf;
+      --accent: #5ea8ff;
+      --accent-strong: #2f86ff;
+      --success: #27c27a;
+      --danger: #ff6b6b;
+      --warn: #ffad43;
+    }
+    html, body {
+      height: 100%;
+      margin: 0;
+      font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial;
+      background: radial-gradient(circle at 15% 10%, #12213b 0%, var(--bg) 45%);
+      color: var(--text);
+    }
+    .app { display: grid; grid-template-columns: minmax(390px, 460px) 1fr; height: 100%; }
+    .left {
+      padding: 16px;
+      overflow: auto;
+      border-right: 1px solid var(--line);
+      background: linear-gradient(180deg, #0f182a 0%, #0b1322 100%);
+    }
+    .right { display: grid; grid-template-rows: 1fr auto; min-width: 0; }
+    .app-title { margin: 0 0 4px 0; font-size: 1.2rem; }
+    .app-subtitle { margin: 0 0 14px 0; color: var(--muted); font-size: 0.92rem; }
+    .panel {
+      border: 1px solid var(--line-soft);
+      background: linear-gradient(160deg, #121d32 0%, #111a2b 65%);
+      border-radius: 12px;
+      padding: 12px;
+      margin-bottom: 12px;
+      box-shadow: 0 10px 24px rgba(2, 8, 20, 0.35);
+    }
+    .panel h2, .panel h3 { margin: 0 0 8px 0; font-size: 0.98rem; }
+    .panel-note { margin: 0 0 10px 0; color: var(--muted); font-size: 0.88rem; }
+    #imgPane { border: 1px solid var(--line); width: 100%; height: 380px; background: #0a111e; overflow:hidden; border-radius: 10px; }
     #imgCanvas { width: 100%; height: 100%; display:block; cursor: crosshair; }
     #map { width: 100%; height: 100%; }
     .affine-preview-layer { transform-origin: 0 0; pointer-events: none; }
-    table { width: 100%; border-collapse: collapse; font-size: 13px; }
-    th, td { border-bottom: 1px solid #eee; padding: 6px 4px; }
+    table { width: 100%; border-collapse: collapse; font-size: 12px; background: rgba(5, 12, 24, 0.25); border-radius: 8px; overflow: hidden; }
+    th, td { border-bottom: 1px solid var(--line-soft); padding: 7px 6px; }
+    th { color: var(--muted); text-align: left; font-weight: 600; }
     .row { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
-    button { cursor: pointer; }
-    .badge { display:inline-block; padding:2px 6px; background:#eee; border-radius:6px; margin-left:6px; font-size:12px; }
-    .warn { color: #b00020; }
-    .ok { color: #0a7f2e; }
+    button {
+      cursor: pointer;
+      border: 1px solid #30507d;
+      background: linear-gradient(180deg, #25406c 0%, #1f355a 100%);
+      color: var(--text);
+      border-radius: 8px;
+      padding: 7px 10px;
+      font-weight: 600;
+      transition: transform 0.08s ease, filter 0.12s ease;
+    }
+    button:hover { filter: brightness(1.08); }
+    button:active { transform: translateY(1px); }
+    button:disabled { opacity: 0.45; cursor: not-allowed; }
+    select, input[type='file'], input[type='range'], textarea {
+      width: 100%;
+      margin-top: 4px;
+      border-radius: 8px;
+      border: 1px solid var(--line);
+      background: var(--bg-raised);
+      color: var(--text);
+      padding: 6px 8px;
+      box-sizing: border-box;
+    }
+    .badge { display:inline-block; padding:3px 8px; background: #1b2a44; border:1px solid #2b4571; color: #c9daff; border-radius:999px; margin-left:6px; font-size:12px; }
+    .warn { color: var(--warn); }
+    .ok { color: var(--success); }
     .controls { display:flex; flex-wrap:wrap; gap:8px; align-items: center; }
     .img-controls { margin: 8px 0; }
-    .code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 12px; white-space: pre; background: #fafafa; border: 1px solid #eee; padding: 8px; }
+    .code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 12px; white-space: pre; background: #0b1322; border: 1px solid var(--line); padding: 8px; border-radius: 8px; }
+    .status-strip { display:flex; align-items:center; justify-content: space-between; gap: 8px; }
+    #status { font-size: 0.88rem; font-weight: 600; }
+    .hint { color: var(--muted); font-size: 0.82rem; }
+    .map-help { padding:10px 12px; border-top:1px solid var(--line); background: #0d1729; color: var(--muted); }
+    @media (max-width: 980px) {
+      .app { grid-template-columns: 1fr; grid-template-rows: auto minmax(400px, 1fr); }
+      .left { border-right: none; border-bottom: 1px solid var(--line); }
+      #imgPane { height: 320px; }
+    }
   </style>
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
 </head>
 <body>
 <div class="app">
   <div class="left">
-    <h2>Image</h2>
+    <h1 class="app-title">Affine Georeferencer</h1>
+    <p class="app-subtitle">A faster 3-step workflow: choose image points, pair map points, then export world + projection files.</p>
+
+    <section class="panel">
+    <h2>1) Source image</h2>
+    <p class="panel-note">Load a raster, then zoom/pan for precise pixel picks.</p>
     <div class="controls">
       <input type="file" id="file" accept="image/*" />
       <button id="loadSample" type="button">Load Sample</button>
@@ -41,9 +116,12 @@
       <button id="zoomReset" type="button">Reset View</button>
       <span id="zoomLevel" class="badge">Zoom: —</span>
     </div>
-    <p>Click the image to add a pixel point. Then click the map to set its ground location.</p>
+    <p class="hint">Tip: Hold <strong>Shift</strong> and drag to pan in the image pane.</p>
+    </section>
 
-    <h3>Control Points</h3>
+    <section class="panel">
+    <h3>2) Control points</h3>
+    <p class="panel-note">Click image first, then click map to create a pair.</p>
     <table id="gcpsTable">
       <thead><tr>
         <th>#</th><th>Pixel (col,row)</th><th>Map (lon,lat)</th><th>Res (map)</th><th></th>
@@ -55,8 +133,10 @@
       <span id="rms" class="badge">RMS: —</span>
       <span id="status"></span>
     </div>
+    </section>
 
-    <h3>CRS & Output</h3>
+    <section class="panel">
+    <h3>3) CRS & output</h3>
     <div class="row">
       <label>Basemap
         <select id="basemapMode">
@@ -96,11 +176,12 @@
 
     <h3>World File Preview</h3>
     <pre id="wldPreview" class="code">(fit to show)</pre>
+    </section>
   </div>
 
   <div class="right">
     <div id="map"></div>
-    <div style="padding:8px; border-top:1px solid #ddd;">
+    <div class="map-help">
       <strong>Map preview:</strong> After “Fit Transform”, your image appears on the map using the same affine as the world file. Check alignment visually.
     </div>
   </div>


### PR DESCRIPTION
### Motivation
- Improve usability by making the georeferencing workflow more discoverable and reducing visual clutter during GCP selection and export. 
- Provide a modern, accessible dark theme and responsive layout so users can work comfortably on a range of screen sizes. 

### Description
- Reworked the left sidebar in `index.html` into a clear 3-step flow with sectioned panels: `1) Source image`, `2) Control points`, and `3) CRS & output`, and added helper text for each step. 
- Rewrote styling with a cohesive dark theme using CSS variables, upgraded controls, badges, and panel visuals, plus responsive rules to stack layout on narrow viewports. 
- Kept the existing georeferencing logic and behavior intact (affine fit, overlay, GCP handling, downloads) while improving UI affordances and discoverability. 
- Added a chronological log entry in `LOG.md` documenting the UI/UX polish pass.

### Testing
- Ran `git diff --check` to ensure no trivial whitespace/diff errors and it passed. 
- Attempted HTML validation with `xmllint --html --noout index.html` but the `xmllint` tool is not available in the environment. 
- Served the app locally and captured a full-page screenshot using Playwright to visually validate the updated UI, producing `artifacts/ui-ux-polish.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b58b367aa88327b7880859de022a0c)